### PR TITLE
typo on Readme code example

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Spark uses backticks as identifiers and the REAL type is transpiled to FLOAT.
 import sqlglot
 
 sql = """WITH baz AS (SELECT a, c FROM foo WHERE a = 1) SELECT f.a, b.b, baz.c, CAST("b"."a" AS REAL) d FROM foo f JOIN bar b ON f.a = b.a LEFT JOIN baz ON f.a = baz.a"""
-sqlglot.transpile(sql, write='spark', identify=True, pretty=True)[0])
+sqlglot.transpile(sql, write='spark', identify=True, pretty=True)[0]
 ```
 
 ```sql


### PR DESCRIPTION
on line 45 of the readme file in the example there is a typo (an extra parenthesis). As a result the example gives a syntax error.

```python
sqlglot.transpile(sql, write='spark', identify=True, pretty=True)[0])
```

just fixing it so the example works